### PR TITLE
fix: only install husky if `.git` folder exists

### DIFF
--- a/bin/sf-install.js
+++ b/bin/sf-install.js
@@ -8,6 +8,7 @@
 
 const chalk = require('chalk');
 const changed = require('../utils/write-dependencies')();
+const exists = require('../utils/exists');
 
 if (changed) {
   const errorHeader = chalk.red('ERROR: ');
@@ -18,5 +19,7 @@ if (changed) {
 } else {
   require('../utils/standardize-pjson')();
   require('../utils/standardize-files')();
-  require('../utils/husky-init')();
+  if (exists('.git')) {
+    require('../utils/husky-init')();
+  }
 }

--- a/bin/sf-lerna-install.js
+++ b/bin/sf-lerna-install.js
@@ -8,6 +8,7 @@
 
 const chalk = require('chalk');
 const log = require('../utils/log');
+const exists = require('../utils/exists');
 const writeDeps = require('../utils/write-dependencies');
 const packageRoot = require('../utils/package-path');
 
@@ -28,8 +29,10 @@ if (changed) {
   const standardizeFiles = require('../utils/standardize-files');
   const standardizePjson = require('../utils/standardize-pjson');
 
-  // Only install husky in the lerna project
-  require('../utils/husky-init')();
+  if (exists('.git')) {
+    // Only install husky in the lerna project
+    require('../utils/husky-init')();
+  }
 
   // Standardize package.json for lerna project, but not files
   log(`Standardize package.json for the lerna project`);


### PR DESCRIPTION
### What does this PR do?
Updates `sf-install` script to only  install husky if `.git` folder exists

**QA**:
1: Clone source-tracking: `git@github.com:forcedotcom/source-tracking.git`
2: `yarn link` this PR into source-tracking
3: Run `rm -rf .git` then `yarn install`,  it shouldn't try to install/initialize husky.

### What issues does this PR fix or reference?
@W-10088025@