### PR TITLE
fix: format plugin schemas and snapshots

### DIFF
--- a/bin/sf-format.js
+++ b/bin/sf-format.js
@@ -9,5 +9,4 @@
 const shell = require('../utils/shelljs');
 
 // Simple one line command. If it needs to be customized, override script in sfdevrc file.
-shell.exec('prettier --write "+(src|test|schemas)/**/*.+(ts|js|json)"');
-shell.exec('prettier --write "command-snapshot.json"');
+shell.exec('prettier --write "+(src|test|schemas)/**/*.+(ts|js|json)|command-snapshot.json"');

--- a/bin/sf-format.js
+++ b/bin/sf-format.js
@@ -9,4 +9,5 @@
 const shell = require('../utils/shelljs');
 
 // Simple one line command. If it needs to be customized, override script in sfdevrc file.
-shell.exec('prettier --write "+(src|test)/**/*.+(ts|js|json)"');
+shell.exec('prettier --write "+(src|test|schemas)/**/*.+(ts|js|json)"');
+shell.exec('prettier --write "command-snapshot.json"');


### PR DESCRIPTION
## What does this PR do?
Makes `sf-format` run on plugin schemas and command snapshots. This will standardize these files so that local environment differences in how they're generated don't affect PR diffs.

[[skip-validate-pr]]