### PR TITLE
fix: remove yarn test from pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn build && yarn test
+yarn build


### PR DESCRIPTION
This removes the `yarn test` from the pre-push hook.

Having to run `yarn test` for every push significantly slows down the development experience for us and our contributors without providing much benefit. Our repos are already setup to require unit tests before merging PRs.