### PR TITLE
fix: force color output on things that use chalk

### DIFF
--- a/utils/sf-config.js
+++ b/utils/sf-config.js
@@ -57,6 +57,11 @@ const PACKAGE_DEFAULTS = {
     },
     'test:only': {
       command: 'nyc mocha "test/**/*.test.ts"',
+      // things that use `chalk` might not output colors with how wireit uses spawn and gha treats that as non-tty
+      // see https://github.com/chalk/supports-color/issues/106
+      env: {
+        FORCE_COLOR: '2',
+      },
       files: ['test/**/*.ts', 'src/**/*.ts', 'tsconfig.json', '.mocha*', 'test/tsconfig.json', '!*.nut.ts', '.nycrc'],
       output: [],
     },


### PR DESCRIPTION
wireit runs parallel stuff in child process, chalk turns off colors when it thinks it's in a non-tty.  gha > spawn is non-tty.   See https://github.com/chalk/supports-color/issues/106

should fix errors that look like this
- https://github.com/salesforcecli/sf-plugins-core/actions/runs/4289179928/jobs/7471969439#step:8:179
- https://github.com/salesforcecli/plugin-apex/actions/runs/4289713156/jobs/7473025531#step:8:137

proof that it works:
https://github.com/salesforcecli/plugin-apex/actions/runs/4299683299/jobs/7495151921.
