### PR TITLE
feat: don't nuke the entire docs directory

### DIFF
--- a/bin/sf-docs.js
+++ b/bin/sf-docs.js
@@ -22,7 +22,9 @@ try {
 
 let outDir = 'docs';
 
-shell.rm('-rf', `${outDir}/*`);
+// preserve perf test files, which are also stored in gh-pages
+shell.exec(`find ./${outDir} -not -path './${outDir}/perf*' -delete`);
+
 outDir = join(packageRoot, outDir, 'tmp');
 
 let command = `yarn typedoc --out ${outDir}`;


### PR DESCRIPTION
preserve perf test results when regenerating docs.

this needs to not delete that dir, but also not cause git conflicts. I don't know enough about worktrees to be sure this is going to work.