### PR TITLE
fix: bump command-ref

### DIFF
--- a/utils/write-dependencies.js
+++ b/utils/write-dependencies.js
@@ -20,7 +20,7 @@ const nonPjsonDependencyMinimums = new Map([
   ['@salesforce/ts-types', '^2.0.2'],
   ['@oclif/core', '^2.8.2'],
   ['@salesforce/cli-plugins-testkit', '^3.3.4'],
-  ['@salesforce/plugin-command-reference', '^3.0.1'],
+  ['@salesforce/plugin-command-reference', '^3.0.2'],
   ['@oclif/plugin-command-snapshot', '^3.3.13'],
   ['eslint-plugin-sf-plugin', '^1.15.5'],
   ['oclif', '^3.9.0'],


### PR DESCRIPTION
bump command-ref to get a version that ignores dev plugins when doing the command-ref topics
https://github.com/salesforcecli/plugin-info/actions/runs/5126588431/jobs/9221273092?pr=420