### PR TITLE
fix: pass extra arg to wireit script in git hook

### DIFF
--- a/utils/husky-init.js
+++ b/utils/husky-init.js
@@ -23,7 +23,7 @@ function initializeHusky() {
     if (localGitHooks.length === 0) {
       shell.exec("yarn husky add .husky/commit-msg 'yarn commitlint --edit'");
       shell.exec("yarn husky add .husky/pre-commit 'yarn lint && yarn pretty-quick --staged'");
-      shell.exec("yarn husky add .husky/pre-push 'yarn build && yarn test --forbid-only'");
+      shell.exec("yarn husky add .husky/pre-push 'yarn build && yarn run test:only -- --forbid-only'");
     }
   } catch (err) {
     if (err.code === 'ENOENT') {


### PR DESCRIPTION
Shane found this wasn't working as expected here: https://github.com/forcedotcom/kit/pull/236

Fixes prepush hook not passing `--forbid-only` correctly to `mocha`.
Will use `test:only` instead of `test` script because the latter only specifies an array of dependencies and doesn't work with extra-args. While it's not the same as before (running lint, format, etc on prepush), it helps catching `it.only` statements.

This has been broken since we moved to `wireit` and it's not a breaking change.

@W-13748069@