### PR TITLE
feat: bump core, sf-plugins-core, oclif

### DIFF
--- a/utils/write-dependencies.js
+++ b/utils/write-dependencies.js
@@ -14,18 +14,18 @@ const { resolveConfig } = require('./sf-config');
  * But, if the target repo has the dep, we want to make sure it meets the minimum version.
  */
 const nonPjsonDependencyMinimums = new Map([
-  ['@salesforce/sf-plugins-core', '^3.1.20'],
+  ['@salesforce/sf-plugins-core', '^4.0.0'],
   ['@salesforce/core', '^5.2.0'],
   ['@salesforce/kit', '^3.0.9'],
   ['@salesforce/ts-types', '^2.0.6'],
-  ['@oclif/core', '^2.15.0'],
+  ['@oclif/core', '^3.0.3'],
   ['@salesforce/cli-plugins-testkit', '^4.2.9'],
   ['@salesforce/source-deploy-retrieve', '^9.7.2'],
   ['@salesforce/source-tracking', '^4.2.10'],
   ['@salesforce/plugin-command-reference', '^3.0.25'],
   ['@oclif/plugin-command-snapshot', '^4.0.2'],
   ['eslint-plugin-sf-plugin', '^1.15.6'],
-  ['oclif', '^3.16.0'],
+  ['oclif', '^4.0.0'],
 ]);
 
 const getVersionNum = (ver) => (ver.startsWith('^') || ver.startsWith('~') ? ver.slice(1) : ver);

--- a/utils/write-dependencies.js
+++ b/utils/write-dependencies.js
@@ -15,7 +15,7 @@ const { resolveConfig } = require('./sf-config');
  */
 const nonPjsonDependencyMinimums = new Map([
   ['@salesforce/sf-plugins-core', '^4.0.0'],
-  ['@salesforce/core', '^5.2.0'],
+  ['@salesforce/core', '^5.3.5'],
   ['@salesforce/kit', '^3.0.9'],
   ['@salesforce/ts-types', '^2.0.6'],
   ['@oclif/core', '^3.0.3'],


### PR DESCRIPTION
Bump minimums for `@oclif/core`, `sf-plugins-core`, and `oclif` to latest major versions

Also bumps `@salesforce/core` since it might not match what `sf-plugins-core` has, which could lead to compilation errors

[skip-validate-pr]