### PR TITLE
fix: keep ts-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To configure what this generates and controls, create a `.sfdevrc` file. Look at
 
 By default, devScripts will try to keep your package.json aligned with its standards.
 
-For example, devScripts will remove dependencies that it provides. If you want to keep yours, you'd add it in to the `sf-dev-rc`. Imagine you need to be on a higher or lower version of mocha that devScripts provides:
+For example, devScripts will remove dependencies that it provides. If you want to keep yours, you'd add it in to the `sfdevrc`. Imagine you need to be on a higher or lower version of mocha that devScripts provides:
 
 ```json
 {

--- a/utils/write-dependencies.js
+++ b/utils/write-dependencies.js
@@ -97,7 +97,6 @@ module.exports = (projectPath) => {
     'pretty-quick',
     'prettier',
     'nyc',
-    'ts-node',
     'mocha',
     'sinon',
     'chai',


### PR DESCRIPTION
ts-node's register process (ex: `.mocharc.json` looks in top-level node_modules for ts-node.  It's not there, so it fails.

This change leaves ts-node in repos that have it.

[skip-validate-pr]