### PR TITLE
fix: use node versus ts-node to run scripts

### DIFF
--- a/utils/sf-config.js
+++ b/utils/sf-config.js
@@ -93,7 +93,8 @@ const resolveConfig = (path) => {
 
   // if path is undefined/null, assume we're executing from a plugin root
   const usesJsBinScripts = existsSync(join(path ?? process.cwd(), 'bin', 'dev.js'));
-  const dev = usesJsBinScripts ? 'ts-node "./bin/dev.js"' : '"./bin/dev"';
+  const loader = 'node --loader ts-node/esm --no-warnings=ExperimentalWarning';
+  const dev = usesJsBinScripts ? `${loader} "./bin/dev.js"` : '"./bin/dev"';
   const pluginDefaults = {
     scripts: {
       ...PACKAGE_DEFAULTS.scripts,


### PR DESCRIPTION
To avoid ESM errors with node v18.19.x when executing dev.js, use node and the ts-node/esm loader.

[skip-validate-pr]