### PR TITLE
chore: bump eslint plugin min

### DIFF
--- a/utils/write-dependencies.js
+++ b/utils/write-dependencies.js
@@ -15,7 +15,7 @@ const { resolveConfig } = require('./sf-config');
  */
 const nonPjsonDependencyMinimums = new Map([
   ['@salesforce/sf-plugins-core', '^5.0.1'],
-  ['@salesforce/core', '^6.4.0'],
+  ['@salesforce/core', '^6.4.2'],
   ['@salesforce/kit', '^3.0.15'],
   ['@salesforce/ts-types', '^2.0.9'],
   ['@oclif/core', '^2.15.0'],
@@ -24,7 +24,7 @@ const nonPjsonDependencyMinimums = new Map([
   ['@salesforce/source-tracking', '^5.0.0'],
   ['@salesforce/plugin-command-reference', '^3.0.25'],
   ['@oclif/plugin-command-snapshot', '^4.0.2'],
-  ['eslint-plugin-sf-plugin', '^1.16.15'],
+  ['eslint-plugin-sf-plugin', '^1.17.0'],
   ['@salesforce/telemetry', '^5.0.0'],
   ['oclif', '^3.16.0'],
 ]);


### PR DESCRIPTION
lots of open PRs look like https://github.com/salesforcecli/plugin-info/pull/601 but result in https://github.com/salesforcecli/plugin-info/actions/runs/7236645537/job/19715404446?pr=601

This'll bump core and the eslint rules to make those unnecessary