### PR TITLE
feat: run shrinkwrap during sf-prepack

### DIFF
--- a/bin/sf-prepack.js
+++ b/bin/sf-prepack.js
@@ -23,11 +23,13 @@ if (isPlugin(packageRoot)) {
       console.log(
         chalk.yellow('Warning:'),
         // eslint-disable-next-line max-len
-        `oclif version ${version} is less than 3.14.0. Please upgrade to 3.14.0 or higher to use generate oclif.lock file.`
+        `oclif version ${version} is less than 3.14.0. Please upgrade to 3.14.0 or higher to generate oclif.lock file.`
       );
     } else {
       shell.exec('oclif lock');
     }
+
+    shell.exec('npm shrinkwrap');
   } else if (shell.which('oclif-dev')) {
     // eslint-disable-next-line no-console
     console.log(chalk.yellow('Warning:'), 'oclif-dev is deprecated. Please use oclif instead.');

--- a/files/gitignore
+++ b/files/gitignore
@@ -1,17 +1,20 @@
 # -- CLEAN
+tmp/
 
 # use yarn by default, so ignore npm
 package-lock.json
+npm-shrinkwrap.json
 
 # never checkin npm config
 .npmrc
 
 # debug logs
-npm-error.log
-yarn-error.log
+*-error.log
+*-debug.log
 
 # compile source
 lib
+dist
 
 # test artifacts
 *xunit.xml
@@ -19,9 +22,14 @@ lib
 *unitcoverage
 .nyc_output
 coverage
+test_session*
 
 # generated docs
 docs
+
+# oclif files
+oclif.manifest.json
+oclif.lock
 
 # -- CLEAN ALL
 node_modules

--- a/utils/sf-config.js
+++ b/utils/sf-config.js
@@ -98,6 +98,8 @@ const resolveConfig = (path) => {
   const pluginDefaults = {
     scripts: {
       ...PACKAGE_DEFAULTS.scripts,
+      'clean:lib': undefined,
+      postpack: 'sf-clean',
       // wireit scripts don't need an entry in pjson scripts.
       // remove these from scripts and let wireit handle them (just repeat running yarn test)
       // https://github.com/google/wireit/blob/main/CHANGELOG.md#094---2023-01-30

--- a/utils/standardize-pjson.js
+++ b/utils/standardize-pjson.js
@@ -13,6 +13,8 @@ const { semverIsLessThan } = require('./semver');
 const PackageJson = require('./package-json');
 const { isPlugin } = require('./project-type');
 
+const PLUGIN_FILES = ['/messages', '/oclif.manifest.json', '/oclif.lock', '/npm-shrinkwrap.json'];
+
 module.exports = (packageRoot = require('./package-path')) => {
   const config = resolveConfig(packageRoot);
   const pjson = new PackageJson(packageRoot);
@@ -25,6 +27,7 @@ module.exports = (packageRoot = require('./package-path')) => {
 
   if (isPlugin(packageRoot)) {
     pjson.contents.oclif.topicSeparator = ' ';
+    pjson.contents.files = [...new Set([...pjson.contents.files, ...PLUGIN_FILES])].sort();
   }
   // GENERATE SCRIPTS
   const scriptList = Object.entries(config.scripts);

--- a/utils/write-dependencies.js
+++ b/utils/write-dependencies.js
@@ -147,6 +147,15 @@ module.exports = (projectPath) => {
     }
   });
 
+  // Check to see if these deps are used by yarn scripts. If not, remove them.
+  const possiblyUnnecessaryDeps = ['shx'];
+
+  possiblyUnnecessaryDeps.forEach((dep) => {
+    if (!Object.values(scripts).some((script) => script?.includes(dep))) {
+      remove(dep);
+    }
+  });
+
   if (added.length > 0) {
     pjson.actions.push(`added/updated devDependencies ${added.join(', ')}`);
   }


### PR DESCRIPTION
- Run `npm shrinkwrap` during `sf-prepack`
- Start managing plugin's `files`
- Add entires to `.gitignore` if they don't exist
  - if the `CLEAN` and `CLEAN ALL` segments exist, it will add the entries to the appropriate section (and remove them from anywhere else in the file)
  - if those segments don't exist, it will simply append the entries to the bottom of the file
- Change `postpack` script for plugins to `sf-clean`
- Remove `shx` devDep if it's not being used by any script

@W-14878497@