### PR TITLE
fix: gitignore standardization on windows

### DIFF
--- a/utils/standardize-files.js
+++ b/utils/standardize-files.js
@@ -81,7 +81,8 @@ function writeGitignore(targetDir) {
   if (!copied) {
     const isAPlugin = isPlugin(targetDir);
     const relevantPatterns = IGNORES.filter((entry) => !entry.plugin || (entry.plugin && isAPlugin));
-    let original = readFileSync(gitignoreTargetPath, 'utf-8');
+    // eslint-disable-next-line no-control-regex
+    let original = readFileSync(gitignoreTargetPath, 'utf-8').replace(new RegExp('\r\n', 'g'), '\n');
 
     const segments = original
       // Segments are defined by "# --" in the gitignore


### PR DESCRIPTION
This is a proposed fix for #301. We replace all CRLF/LF line endings with LF line endings, and then perform all actions as previously implemented. I had debated attempting to convert from CRLF to LF and then back into CRLF to write the file, but that seemed rather complex for something like a .gitignore file. If we think that is a better solution, I am happy to explore that option further.