### PR TITLE
fix: add --ignore-signing-artifacts flag to sf-clean

### DIFF
--- a/bin/sf-clean.js
+++ b/bin/sf-clean.js
@@ -12,7 +12,9 @@ const shell = require('../utils/shelljs');
 const log = require('../utils/log');
 const loadRootPath = require('../utils/load-root-path');
 
-const cleanAll = process.argv[2] === 'all';
+const argv = process.argv.slice(2);
+const cleanAll = argv.includes('all');
+const ignoreSigningArtifacts = argv.includes('--ignore-signing-artifacts');
 
 let toClean = ['lib'];
 let toCleanAll = ['node_modules'];
@@ -55,6 +57,10 @@ if (gitignorePath) {
 // Add defaults for clean all
 if (cleanAll) {
   toClean = [...toClean, ...toCleanAll];
+}
+
+if (ignoreSigningArtifacts) {
+  toClean = toClean.filter((item) => !item.endsWith('.tgz') && !item.endsWith('.sig'));
 }
 
 log(`rm -rf ${toClean}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/dev-scripts",
-  "version": "8.4.0",
+  "version": "8.4.1-qa.0",
   "description": "Standardize package.json scripts and config files for Salesforce projects.",
   "repository": "forcedotcom/dev-scripts",
   "bin": {

--- a/utils/sf-config.js
+++ b/utils/sf-config.js
@@ -99,7 +99,7 @@ const resolveConfig = (path) => {
     scripts: {
       ...PACKAGE_DEFAULTS.scripts,
       'clean:lib': undefined,
-      postpack: 'sf-clean',
+      postpack: 'sf-clean --ignore-signing-artifacts',
       // wireit scripts don't need an entry in pjson scripts.
       // remove these from scripts and let wireit handle them (just repeat running yarn test)
       // https://github.com/google/wireit/blob/main/CHANGELOG.md#094---2023-01-30


### PR DESCRIPTION
Adds `--ignore-signing-artifacts` flag to sf-clean to prevent the clean up of `*.sig` and `*.tgz` files that are still needed for plugin signing

Verified by https://github.com/salesforcecli/plugin-settings/actions/runs/8052090396

[skip-validate-pr]