### PR TITLE
feat: only generate lockfiles for jit plugins

### DIFF
--- a/.github/workflows/update-jit-list.yml
+++ b/.github/workflows/update-jit-list.yml
@@ -1,0 +1,37 @@
+name: update-jit-list
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run every Wednesday at 14:00 UTC
+    - cron: '0 14 * * 3'
+
+jobs:
+  update-jit-list:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: |
+          npm view @salesforce/cli oclif.jitPlugins --json | jq keys > jit-plugins.json
+      - uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
+        id: github-user-info
+        with:
+          SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+      - uses: salesforcecli/github-workflows/.github/actions/gitConfig@main
+        with:
+          username: ${{ steps.github-user-info.outputs.username }}
+          email: ${{ steps.github-user-info.outputs.email }}
+      # Push changes if 'git status' is not empty
+      - run: |
+          if [[ -n $(git status --short) ]]; then
+            git add -A
+            git commit -m "fix: update jit-plugins.json"
+            git push
+          else
+            echo "Already up to date"
+          fi

--- a/.github/workflows/update-plugin-list.yml
+++ b/.github/workflows/update-plugin-list.yml
@@ -1,4 +1,4 @@
-name: update-jit-list
+name: update-plugin-list
 
 on:
   workflow_dispatch:
@@ -7,7 +7,7 @@ on:
     - cron: '0 14 * * 3'
 
 jobs:
-  update-jit-list:
+  update-plugin-list:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,6 +17,7 @@ jobs:
         with:
           node-version: lts/*
       - run: |
+          npm view @salesforce/cli oclif.plugins --json | jq  '[.[] | select(contains("@salesforce"))]' > core-plugins.json
           npm view @salesforce/cli oclif.jitPlugins --json | jq keys > jit-plugins.json
       - uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
         id: github-user-info
@@ -30,7 +31,7 @@ jobs:
       - run: |
           if [[ -n $(git status --short) ]]; then
             git add -A
-            git commit -m "fix: update jit-plugins.json"
+            git commit -m "fix: update plugin lists"
             git push
           else
             echo "Already up to date"

--- a/bin/sf-prepack.js
+++ b/bin/sf-prepack.js
@@ -8,17 +8,19 @@
 
 const chalk = require('chalk');
 const shell = require('../utils/shelljs');
-const { isPlugin, isJitPlugin } = require('../utils/project-type');
+const { determineProjectType } = require('../utils/project-type');
 const packageRoot = require('../utils/package-path');
 const { semverIsLessThan } = require('../utils/semver');
 
 shell.exec('yarn build');
 
-if (isPlugin(packageRoot)) {
+const projectType = determineProjectType(packageRoot);
+
+if (projectType !== 'other') {
   if (shell.which('oclif')) {
     shell.exec('oclif manifest');
 
-    if (isJitPlugin(packageRoot)) {
+    if (projectType !== 'core-plugin') {
       const version = shell.exec('oclif --version', { silent: true }).stdout.trim().replace('oclif/', '').split(' ')[0];
       if (semverIsLessThan(version, '3.14.0')) {
         // eslint-disable-next-line no-console

--- a/bin/sf-prepack.js
+++ b/bin/sf-prepack.js
@@ -8,7 +8,7 @@
 
 const chalk = require('chalk');
 const shell = require('../utils/shelljs');
-const { isPlugin } = require('../utils/project-type');
+const { isPlugin, isJitPlugin } = require('../utils/project-type');
 const packageRoot = require('../utils/package-path');
 const { semverIsLessThan } = require('../utils/semver');
 
@@ -16,20 +16,23 @@ shell.exec('yarn build');
 
 if (isPlugin(packageRoot)) {
   if (shell.which('oclif')) {
-    shell.exec('oclif manifest .');
-    const version = shell.exec('oclif --version', { silent: true }).stdout.trim().replace('oclif/', '').split(' ')[0];
-    if (semverIsLessThan(version, '3.14.0')) {
-      // eslint-disable-next-line no-console
-      console.log(
-        chalk.yellow('Warning:'),
-        // eslint-disable-next-line max-len
-        `oclif version ${version} is less than 3.14.0. Please upgrade to 3.14.0 or higher to generate oclif.lock file.`
-      );
-    } else {
-      shell.exec('oclif lock');
-    }
+    shell.exec('oclif manifest');
 
-    shell.exec('npm shrinkwrap');
+    if (isJitPlugin(packageRoot)) {
+      const version = shell.exec('oclif --version', { silent: true }).stdout.trim().replace('oclif/', '').split(' ')[0];
+      if (semverIsLessThan(version, '3.14.0')) {
+        // eslint-disable-next-line no-console
+        console.log(
+          chalk.yellow('Warning:'),
+          // eslint-disable-next-line max-len
+          `oclif version ${version} is less than 3.14.0. Please upgrade to 3.14.0 or higher to generate oclif.lock file.`
+        );
+      } else {
+        shell.exec('oclif lock');
+      }
+
+      shell.exec('npm shrinkwrap');
+    }
   } else if (shell.which('oclif-dev')) {
     // eslint-disable-next-line no-console
     console.log(chalk.yellow('Warning:'), 'oclif-dev is deprecated. Please use oclif instead.');

--- a/core-plugins.json
+++ b/core-plugins.json
@@ -1,0 +1,19 @@
+[
+  "@salesforce/plugin-apex",
+  "@salesforce/plugin-auth",
+  "@salesforce/plugin-data",
+  "@salesforce/plugin-deploy-retrieve",
+  "@salesforce/plugin-info",
+  "@salesforce/plugin-limits",
+  "@salesforce/plugin-marketplace",
+  "@salesforce/plugin-org",
+  "@salesforce/plugin-packaging",
+  "@salesforce/plugin-schema",
+  "@salesforce/plugin-settings",
+  "@salesforce/plugin-sobject",
+  "@salesforce/plugin-source",
+  "@salesforce/plugin-telemetry",
+  "@salesforce/plugin-templates",
+  "@salesforce/plugin-trust",
+  "@salesforce/plugin-user"
+]

--- a/jit-plugins.json
+++ b/jit-plugins.json
@@ -1,0 +1,11 @@
+[
+  "@salesforce/plugin-custom-metadata",
+  "@salesforce/plugin-community",
+  "@salesforce/plugin-dev",
+  "@salesforce/plugin-devops-center",
+  "@salesforce/plugin-env",
+  "@salesforce/plugin-functions",
+  "@salesforce/plugin-signups",
+  "@salesforce/sfdx-plugin-lwc-test",
+  "@salesforce/sfdx-scanner"
+]

--- a/utils/project-type.js
+++ b/utils/project-type.js
@@ -8,7 +8,13 @@
 const { join } = require('path');
 const { readFileSync } = require('fs');
 
+const IS_PLUGIN_CACHE = new Map();
+
 exports.isPlugin = function (packageRoot) {
+  if (IS_PLUGIN_CACHE.has(packageRoot)) {
+    return IS_PLUGIN_CACHE.get(packageRoot);
+  }
+
   let isPlugin = false;
   try {
     const contents = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf-8'));
@@ -16,5 +22,29 @@ exports.isPlugin = function (packageRoot) {
   } catch (err) {
     /* do nothing */
   }
+
+  IS_PLUGIN_CACHE.set(packageRoot, isPlugin);
   return isPlugin;
+};
+
+const IS_JIT_PLUGIN_CACHE = new Map();
+
+exports.isJitPlugin = function (packageRoot) {
+  if (IS_JIT_PLUGIN_CACHE.has(packageRoot)) {
+    return IS_JIT_PLUGIN_CACHE.get(packageRoot);
+  }
+
+  let isJitPlugin = false;
+  try {
+    const jitPluginsList = readFileSync(join(__dirname, '..', 'jit-plugins.json'), 'utf-8');
+    const jitPlugins = JSON.parse(jitPluginsList);
+
+    const contents = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf-8'));
+    isJitPlugin = contents && !!contents.oclif && jitPlugins.includes(contents.name);
+  } catch {
+    /* do nothing */
+  }
+
+  IS_JIT_PLUGIN_CACHE.set(packageRoot, isJitPlugin);
+  return isJitPlugin;
 };

--- a/utils/standardize-pjson.js
+++ b/utils/standardize-pjson.js
@@ -11,10 +11,10 @@ const { resolveConfig } = require('./sf-config');
 const { semverIsLessThan } = require('./semver');
 
 const PackageJson = require('./package-json');
-const { isPlugin, isJitPlugin } = require('./project-type');
+const { determineProjectType } = require('./project-type');
 
 const PLUGIN_FILES = ['/messages', '/oclif.manifest.json'];
-const PLUGIN_FILES_BLOCK_LIST = ['/oclif.lock', '/npm-shrinkwrap.json'];
+const CORE_PLUGIN_FILES_BLOCK_LIST = ['/oclif.lock', '/npm-shrinkwrap.json'];
 const JIT_PLUGIN_FILES = ['/messages', '/oclif.manifest.json', '/oclif.lock', '/npm-shrinkwrap.json'];
 
 module.exports = (packageRoot = require('./package-path')) => {
@@ -27,15 +27,18 @@ module.exports = (packageRoot = require('./package-path')) => {
     pjson.actions.push(`updating license`);
   }
 
-  if (isPlugin(packageRoot)) {
-    pjson.contents.oclif.topicSeparator = ' ';
-    pjson.contents.files = [
-      ...new Set([...pjson.contents.files.filter((f) => !PLUGIN_FILES_BLOCK_LIST.includes(f)), ...PLUGIN_FILES]),
-    ].sort();
+  const type = determineProjectType(packageRoot);
+
+  if (type === 'jit-plugin') {
+    // ensure that jit plugins have the correct files
+    pjson.contents.files = [...new Set([...pjson.contents.files, ...JIT_PLUGIN_FILES])].sort();
   }
 
-  if (isJitPlugin(packageRoot)) {
-    pjson.contents.files = [...new Set([...pjson.contents.files, ...JIT_PLUGIN_FILES])].sort();
+  if (type === 'core-plugin') {
+    // ensure that core plugins have the correct files and do not have any in the block list
+    pjson.contents.files = [
+      ...new Set([...pjson.contents.files.filter((f) => !CORE_PLUGIN_FILES_BLOCK_LIST.includes(f)), ...PLUGIN_FILES]),
+    ].sort();
   }
 
   // GENERATE SCRIPTS


### PR DESCRIPTION
Only generate oclif.lock and npm-shrinkwrap.json for JIT plugins

We'll use a hardcoded list of JIT plugins (`jit-plugins.json`) to check if a given plugin is a JIT plugin. This list will get updated every Wednesday at 14:00 UTC by a cronjob.

@W-15620196@