### PR TITLE
fix: respect current EOL in gitignore

### DIFF
--- a/bin/sf-clean.js
+++ b/bin/sf-clean.js
@@ -8,6 +8,7 @@
 
 const { readFileSync } = require('fs');
 const { join } = require('path');
+const { EOL } = require('node:os');
 const shell = require('../utils/shelljs');
 const log = require('../utils/log');
 const loadRootPath = require('../utils/load-root-path');
@@ -28,7 +29,7 @@ if (gitignorePath) {
     // Segments are defined by "# --" in the gitignore
     .split('# --')
     // Turn each segment into list of valid gitignore lines
-    .map((segment) => segment.split('\n').filter((line) => line && !line.startsWith('#')))
+    .map((segment) => segment.split(EOL).filter((line) => line && !line.startsWith('#')))
     // Maps segment name to list of valid gitignore lines
     .reduce((map, segment) => {
       const segmentName = (segment.shift() || '').trim();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/dev-scripts",
-  "version": "9.1.2",
+  "version": "9.1.3-dev.0",
   "description": "Standardize package.json scripts and config files for Salesforce projects.",
   "repository": "forcedotcom/dev-scripts",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/dev-scripts",
-  "version": "9.1.3-dev.0",
+  "version": "9.1.3-dev.1",
   "description": "Standardize package.json scripts and config files for Salesforce projects.",
   "repository": "forcedotcom/dev-scripts",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/dev-scripts",
-  "version": "9.1.3-dev.1",
+  "version": "9.1.3-dev.2",
   "description": "Standardize package.json scripts and config files for Salesforce projects.",
   "repository": "forcedotcom/dev-scripts",
   "bin": {

--- a/utils/standardize-files.js
+++ b/utils/standardize-files.js
@@ -83,6 +83,13 @@ function writeGitignore(targetDir) {
     const relevantPatterns = IGNORES.filter((entry) => !entry.plugin || (entry.plugin && isAPlugin));
     let original = readFileSync(gitignoreTargetPath, 'utf-8');
 
+    // respect the file EOL (`CRLF` or `LF`).
+    //
+    // we can't use node's `os.EOL` because that assumes:
+    //   * unix only uses `CL`
+    //   * win only uses `CRLF`
+    //
+    // when all 4 scenarios are completely valid
     const originalEOL = original.includes('\r\n') ? '\r\n' : '\n';
 
     const segments = original

--- a/utils/standardize-files.js
+++ b/utils/standardize-files.js
@@ -6,6 +6,7 @@
  */
 
 const { join } = require('path');
+const { EOL } = require('node:os');
 const { readFileSync, unlinkSync, copyFileSync, writeFileSync } = require('fs');
 const log = require('./log');
 const exists = require('./exists');
@@ -87,7 +88,7 @@ function writeGitignore(targetDir) {
       // Segments are defined by "# --" in the gitignore
       .split('# --')
       // Turn each segment into list of valid gitignore lines
-      .map((segment) => segment.split('\n'))
+      .map((segment) => segment.split(EOL))
       // Maps segment name to list of valid gitignore lines
       .reduce((map, segment) => {
         const segmentName = (segment.shift() || '').trim();
@@ -112,7 +113,7 @@ function writeGitignore(targetDir) {
       }
 
       if (needsWrite) {
-        writeFileSync(gitignoreTargetPath, `${original}\n${toAdd.join('\n')}`);
+        writeFileSync(gitignoreTargetPath, `${original}${EOL}${toAdd.join(EOL)}`);
         return gitignoreTargetPath;
       }
     } else {
@@ -135,11 +136,11 @@ function writeGitignore(targetDir) {
         for (const [section, lines] of Object.entries(updatedSegments)) {
           if (lines.length === 0) continue;
           original = original.replace(
-            `# -- ${section}\n${segments[section].join('\n')}`,
-            `# -- ${section}\n${[...segments[section], ...lines, '\n'].join('\n')}`
+            `# -- ${section}${EOL}${segments[section].join(EOL)}`,
+            `# -- ${section}${EOL}${[...segments[section], ...lines, EOL].join(EOL)}`
           );
         }
-        writeFileSync(gitignoreTargetPath, original.trimEnd() + '\n');
+        writeFileSync(gitignoreTargetPath, original.trimEnd() + EOL);
         return gitignoreTargetPath;
       }
     }

--- a/utils/standardize-files.js
+++ b/utils/standardize-files.js
@@ -6,7 +6,6 @@
  */
 
 const { join } = require('path');
-const { EOL } = require('node:os');
 const { readFileSync, unlinkSync, copyFileSync, writeFileSync } = require('fs');
 const log = require('./log');
 const exists = require('./exists');
@@ -84,11 +83,13 @@ function writeGitignore(targetDir) {
     const relevantPatterns = IGNORES.filter((entry) => !entry.plugin || (entry.plugin && isAPlugin));
     let original = readFileSync(gitignoreTargetPath, 'utf-8');
 
+    const originalEOL = original.includes('\r\n') ? '\r\n' : '\n';
+
     const segments = original
       // Segments are defined by "# --" in the gitignore
       .split('# --')
       // Turn each segment into list of valid gitignore lines
-      .map((segment) => segment.split(EOL))
+      .map((segment) => segment.split(originalEOL))
       // Maps segment name to list of valid gitignore lines
       .reduce((map, segment) => {
         const segmentName = (segment.shift() || '').trim();
@@ -113,7 +114,7 @@ function writeGitignore(targetDir) {
       }
 
       if (needsWrite) {
-        writeFileSync(gitignoreTargetPath, `${original}${EOL}${toAdd.join(EOL)}`);
+        writeFileSync(gitignoreTargetPath, `${original}${originalEOL}${toAdd.join(originalEOL)}`);
         return gitignoreTargetPath;
       }
     } else {
@@ -136,11 +137,11 @@ function writeGitignore(targetDir) {
         for (const [section, lines] of Object.entries(updatedSegments)) {
           if (lines.length === 0) continue;
           original = original.replace(
-            `# -- ${section}${EOL}${segments[section].join(EOL)}`,
-            `# -- ${section}${EOL}${[...segments[section], ...lines, EOL].join(EOL)}`
+            `# -- ${section}${originalEOL}${segments[section].join(originalEOL)}`,
+            `# -- ${section}${originalEOL}${[...segments[section], ...lines, originalEOL].join(originalEOL)}`
           );
         }
-        writeFileSync(gitignoreTargetPath, original.trimEnd() + EOL);
+        writeFileSync(gitignoreTargetPath, original.trimEnd() + originalEOL);
         return gitignoreTargetPath;
       }
     }


### PR DESCRIPTION
Fixes: https://github.com/forcedotcom/dev-scripts/issues/301

Problem:
`sf-install` reads the `.gitignore` in the project and tries to split the content by `\n` (even on windows).
This messes up your gitignore if it uses `CRLF` (most common on windows but can happen on linux/mac too) like in the linked issue above.

dev-scripts now will detect the EOL used by the local file and use that for parsing the content and final write.
We can't use node's `os.EOL` because it assumes unix === `LF` and win === `CRLF`.

same change in `sf-clean`

NOTE:
there's a file check done here to see if the `.gitignore` in the project matches the template:

https://github.com/forcedotcom/dev-scripts/blob/e2efc93a4af12dc5953d1beb673cc768a7e620a6/utils/standardize-files.js#L79

https://github.com/forcedotcom/dev-scripts/blob/e2efc93a4af12dc5953d1beb673cc768a7e620a6/utils/standardize-files.js#L35C1-L48C2

`isDifferent` just normalizes line endings for comparision so that's left as is.


## Testing

1. clone `plugin-info` (or any other of our plugins)
2. make `.gitignore` use CRLF (open in vscode click on `LF` at the bottom of the screen, choose `CRLF` and save the file
![Screenshot 2024-06-04 at 5 01 56 PM](https://github.com/forcedotcom/dev-scripts/assets/6853656/a660a4e4-d488-44d4-a559-b0118f6f455b)

### `sf-install`
now run `yarn` (will run `sf-install`), it'll print `standardizing config files for plugin-info` and if you open the file you'll see it's missing the `CLEAN ALL` items and other stuff.

### `sf-clean`
restore changes (clean git status), redo step 1 & 2 and run `yarn clean`, will print:
```
➜  plugin-info git:(main) ✗ yarn clean
yarn run v1.22.19
$ sf-clean
,oclif.lockfest.json
``` 

but the gitignore have more stuff in it that's missing because of `CRLF`.

install the prerelease in this branch and the steps above should work wether gitignore uses `LF` or `CRLF` on any os.


@W-15748612@
