### PR TITLE
fix(deps): typedoc plugin for v0.26 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "source-map-support": "^0.5.21",
     "ts-node": "^10.9.2",
     "typedoc": "^0.26.5",
-    "typedoc-plugin-missing-exports": "0.23.0",
+    "typedoc-plugin-missing-exports": "^3.0.0",
     "typescript": "^5.5.4",
     "wireit": "^0.14.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4094,10 +4094,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typedoc-plugin-missing-exports@0.23.0:
-  version "0.23.0"
-  resolved "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-0.23.0.tgz#076df6ffce4d84e8097be009b7c62a17d58477a5"
-  integrity sha512-9smahDSsFRno9ZwoEshQDuIYMHWGB1E6LUud5qMxR2wNZ0T4DlZz0QjoK3HzXtX34mUpTH0dYtt7NQUK4D6B6Q==
+typedoc-plugin-missing-exports@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-3.0.0.tgz#47ab7cf9b91967f50550b7f07549ed1b743f3726"
+  integrity sha512-R7D8fYrK34mBFZSlF1EqJxfqiUSlQSmyrCiQgTQD52nNm6+kUtqwiaqaNkuJ2rA2wBgWFecUA8JzHT7x2r7ePg==
 
 typedoc@^0.26.5:
   version "0.26.5"


### PR DESCRIPTION
3.0.0 supports 0.26, drops support for older typedoc version