### PR TITLE
W-18302796: Bump wireit for new cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typedoc": "^0.26.5",
     "typedoc-plugin-missing-exports": "^3.0.0",
     "typescript": "^5.5.4",
-    "wireit": "^0.14.5"
+    "wireit": "^0.14.12"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4199,10 +4199,10 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-wireit@^0.14.5:
-  version "0.14.5"
-  resolved "https://registry.npmjs.org/wireit/-/wireit-0.14.5.tgz#cd1c4136444c8dbe655f34f60fe2454a9e69d430"
-  integrity sha512-K4ka9YBpSyD6pmFZYTJd4VpPsAiPT6j/fOtLzYgnKWlPIMM7lAZjQQ30H7urO+Lqx1Wvrw88tQHBz4njy+lglg==
+wireit@^0.14.12:
+  version "0.14.12"
+  resolved "https://registry.npmjs.org/wireit/-/wireit-0.14.12.tgz#c35788b4be4a796a8d05d204ec7d3f5c4b355d71"
+  integrity sha512-gNSd+nZmMo6cuICezYXRIayu6TSOeCSCDzjSF0q6g8FKDsRbdqrONrSZYzdk/uBISmRcv4vZtsno6GyGvdXwGA==
   dependencies:
     brace-expansion "^4.0.0"
     chokidar "^3.5.3"


### PR DESCRIPTION
Wireit needs to be bumped in our repos for them to be able to work with the new wireit Github Action (new cache).

NOTE: Merge this after the GHA changes https://github.com/salesforcecli/github-workflows/pull/140

See https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002CN26RYAT/view for more details.

[@W-18302796@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-18302796)