### PR TITLE
fix: drop premature TypeScript 6 range

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "ts-node": "^10.9.2",
     "typedoc": "^0.26.11",
     "typedoc-plugin-missing-exports": "^3.1.0",
-    "typescript": "^5.5.4 || ^6",
+    "typescript": "^5.5.4",
     "wireit": "^0.14.13"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Removes the `|| ^6` from the `typescript` dependency range, reverting to `^5.5.4`
- TS 6 is not yet stable; the premature range causes `write-dependencies.js` to propagate `^5.5.4 || ^6` to all consumer repos on every install, which could break builds if TS 6 introduces breaking changes

## Test plan
- [ ] Verify `sf-install` no longer writes `|| ^6` into consumer `package.json` files